### PR TITLE
Delete row after BatchWriter iteration

### DIFF
--- a/src/Writer/BatchWriter.php
+++ b/src/Writer/BatchWriter.php
@@ -42,6 +42,7 @@ class BatchWriter implements Writer
         $this->delegate->prepare();
 
         $this->queue = new \SplQueue();
+        $this->queue->setIteratorMode(\SplDoublyLinkedList::IT_MODE_DELETE);
     }
 
     /**

--- a/tests/Writer/BatchWriterTest.php
+++ b/tests/Writer/BatchWriterTest.php
@@ -2,19 +2,34 @@
 
 namespace Port\Tests\Writer;
 
+use PHPUnit_Framework_MockObject_MockObject as Mock;
+use Port\Writer;
 use Port\Writer\BatchWriter;
 
 class BatchWriterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Mock|Writer
+     */
+    private $delegate;
+
+    protected function setUp()
+    {
+        $this->delegate = $this->getMock('Port\Writer');
+    }
+
     public function testWriteItem()
     {
-        $delegate = $this->getMock('Port\Writer');
-        $writer = new BatchWriter($delegate);
+        $writer = new BatchWriter($this->delegate);
 
-        $delegate->expects($this->once())
+        $this
+            ->delegate
+            ->expects($this->once())
             ->method('prepare');
 
-        $delegate->expects($this->never())
+        $this
+            ->delegate
+            ->expects($this->never())
             ->method('writeItem');
 
         $writer->prepare();
@@ -23,15 +38,32 @@ class BatchWriterTest extends \PHPUnit_Framework_TestCase
 
     public function testFlush()
     {
-        $delegate = $this->getMock('Port\Writer');
-        $writer = new BatchWriter($delegate);
+        $writer = new BatchWriter($this->delegate);
 
-        $delegate->expects($this->exactly(20))
+        $this
+            ->delegate
+            ->expects($this->exactly(20))
             ->method('writeItem');
 
         $writer->prepare();
 
         for ($i = 0; $i < 20; $i++) {
+            $writer->writeItem(['Test']);
+        }
+    }
+
+    public function testMultipleBatches()
+    {
+        $writer = new BatchWriter($this->delegate, 1);
+
+        $this
+            ->delegate
+            ->expects($this->exactly(3))
+            ->method('writeItem');
+
+        $writer->prepare();
+
+        for ($i = 0; $i < 3; $i++) {
             $writer->writeItem(['Test']);
         }
     }


### PR DESCRIPTION
Right now BatchWriter iterates queue over and over again. This PR fixes it.

It seems like this bug was fixed here https://github.com/ddeboer/data-import/commit/ce5004f4ccaed8f4321f0b2b2f6d5c76d00c658a, not sure why this repository wasn't updated.
