### PR TITLE
add support for converting to null

### DIFF
--- a/src/ValueConverter/MappingValueConverter.php
+++ b/src/ValueConverter/MappingValueConverter.php
@@ -24,13 +24,13 @@ class MappingValueConverter
 
     public function __invoke($input)
     {
-        if (!isset($this->mapping[$input])) {
-            throw new UnexpectedValueException(sprintf(
-                'Cannot find mapping for value "%s"',
-                $input
-            ));
+        if (isset($this->mapping[$input]) || array_key_exists($input, $this->mapping)) {
+            return $this->mapping[$input];
         }
 
-        return $this->mapping[$input];
+        throw new UnexpectedValueException(sprintf(
+            'Cannot find mapping for value "%s"',
+            $input
+        ));
     }
 }

--- a/tests/ValueConverter/MappingValueConverterTest.php
+++ b/tests/ValueConverter/MappingValueConverterTest.php
@@ -1,21 +1,30 @@
 <?php
+
 namespace Port\Tests\ValueConverter;
 
 use Port\ValueConverter\MappingValueConverter;
 
 class MappingValueConverterTest extends \PHPUnit_Framework_TestCase
 {
+    public function testConvert()
+    {
+        $converter = new MappingValueConverter([
+            'source' => 'destination',
+            'foo' => null,
+        ]);
+
+        $this->assertSame('destination', call_user_func($converter, 'source'));
+        $this->assertNull(call_user_func($converter, 'foo'));
+    }
+
     /**
      * @expectedException Port\Exception\UnexpectedValueException
      * @expectedExceptionMessage Cannot find mapping for value "unexpected value"
      */
-    public function testConvert()
+    public function testExceptionIsThrownWhenValueIsNotFound()
     {
-        $converter = new MappingValueConverter(array(
-            'source' => 'destination'
-        ));
+        $converter = new MappingValueConverter([]);
 
-        $this->assertSame('destination', call_user_func($converter, 'source'));
         call_user_func($converter, 'unexpected value');
     }
 }


### PR DESCRIPTION
`MappingValueConverter` didn't support converting a value to `null`, which this PR addresses.