### PR TITLE
added an interface for reader factories

### DIFF
--- a/src/Reader/ReaderFactory.php
+++ b/src/Reader/ReaderFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Port\Csv;
+
+use Port\Reader;
+
+/**
+ * Factory interface to create file based readers
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org
+ */
+interface ReaderFactory
+{
+    /**
+     * @param \SplFileObject $file
+     *
+     * @return Reader
+     */
+    public function getReader(\SplFileObject $file);
+}


### PR DESCRIPTION
this would allow us to type hint this interface, rather than the `CsvReaderFactory` making the class useable for all other file types:
https://github.com/solutionDrive/SyliusImportExportPlugin/blob/master/src/Importer/AbstractImporter.php#L39

Obviously all the reader factories would then need to implement this interface.