### PR TITLE
add Reader::getColumnHeaders()

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -9,4 +9,10 @@ namespace Port;
  */
 interface Reader extends \Iterator
 {
+    /**
+     * Get column headers
+     *
+     * @return array
+     */
+    public function getColumnHeaders();
 }

--- a/src/Reader/ArrayReader.php
+++ b/src/Reader/ArrayReader.php
@@ -9,4 +9,16 @@ namespace Port\Reader;
  */
 class ArrayReader extends \ArrayIterator implements CountableReader
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnHeaders()
+    {
+        $current = $this->current();
+        if (empty($current)) {
+            reutrn array();
+        }
+
+        return array_keys($current);
+    }
 }


### PR DESCRIPTION
These methods are currently only available in the CSV and Excel Readers but I think they would make sense in all Readers since they all are based on the concept of having the same keys for all rows.

Relates to https://github.com/FriendsOfSylius/SyliusImportExportPlugin/pull/1/files#diff-430ec8a1e1948f778b7c7e74e3cf306bR80