### PR TITLE
Fix risky PHPUnit tests and phpspec

### DIFF
--- a/spec/ResultSpec.php
+++ b/spec/ResultSpec.php
@@ -7,9 +7,10 @@ use Prophecy\Argument;
 
 class ResultSpec extends ObjectBehavior
 {
-    function let(\DateTime $startTime, \DateTime $endTime, \SplObjectStorage $exceptions, \DateInterval $elapsed)
+    function let(\SplObjectStorage $exceptions)
     {
-        $startTime->diff($endTime)->willReturn($elapsed);
+        $startTime = new \DateTime('2018-02-10T00:00:00+00:00');
+        $endTime = new \DateTime('2018-02-11T00:00:00+00:00');
         $exceptions->count()->willReturn(4);
         $this->beConstructedWith('name', $startTime, $endTime, 10, $exceptions);
     }
@@ -24,19 +25,19 @@ class ResultSpec extends ObjectBehavior
         $this->getName()->shouldReturn('name');
     }
 
-    function it_has_a_start_time(\DateTime $startTime)
+    function it_has_a_start_time()
     {
-        $this->getStartTime()->shouldReturn($startTime);
+        $this->getStartTime()->shouldBeLike(new \DateTime('2018-02-10T00:00:00+00:00'));
     }
 
-    function it_has_a_end_time(\DateTime $endTime)
+    function it_has_a_end_time()
     {
-        $this->getEndTime()->shouldReturn($endTime);
+        $this->getEndTime()->shouldBeLike(new \DateTime('2018-02-11T00:00:00+00:00'));
     }
 
-    function it_has_an_elapsed_time(\DateInterval $elapsed)
+    function it_has_an_elapsed_time()
     {
-        $this->getElapsed()->shouldReturn($elapsed);
+        $this->getElapsed()->shouldBeLike(new \DateInterval('P1D'));
     }
 
     function it_has_an_error_count()

--- a/tests/Writer/CallbackWriterTest.php
+++ b/tests/Writer/CallbackWriterTest.php
@@ -10,6 +10,9 @@ use Port\Writer\CallbackWriter;
  */
 class CallbackWriterTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPrepare()
     {
         $callable = function(array $item) {
@@ -33,6 +36,9 @@ class CallbackWriterTest extends TestCase
         $this->assertEquals('bar,foo', $string);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testFinish()
     {
         $callable = function(array $item) {


### PR DESCRIPTION
When I run `vendor/bin/phpunit`, I had the warnings:

```
There were 2 risky tests:

1) Port\Tests\Writer\CallbackWriterTest::testPrepare
This test did not perform any assertions

2) Port\Tests\Writer\CallbackWriterTest::testFinish
This test did not perform any assertions
```

When I run `vendor/bin/phpspec run`, I have the errors:

```
     Port\Result

  17  ! is initializable
        exception [err:Error("Call to a member function sub() on null")] has been thrown.
  22  ! has a name
        exception [err:Error("Call to a member function sub() on null")] has been thrown.
  27  ! has a start time
        exception [err:Error("Call to a member function sub() on null")] has been thrown.
  32  ! has a end time
        exception [err:Error("Call to a member function sub() on null")] has been thrown.
...
```

To fix specs we treat DateTime as a value object and we don't mock them
@see https://github.com/phpspec/phpspec/issues/887
