### PR TITLE
Fix AbstractStreamWriter::setCloseStreamOnFinish @return annotation

### DIFF
--- a/src/Writer/AbstractStreamWriter.php
+++ b/src/Writer/AbstractStreamWriter.php
@@ -84,7 +84,7 @@ abstract class AbstractStreamWriter implements Writer
      *
      * @param boolean $closeStreamOnFinish
      *
-     * @return boolean
+     * @return $this
      */
     public function setCloseStreamOnFinish($closeStreamOnFinish = true)
     {


### PR DESCRIPTION
The incorrect `@return` type breaks code auto-completion in IDE when using chainable interfaces like this one,