### PR TITLE
Update documentation for portphp/spreadsheet

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 4
 [*.yml*]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/include/excel.md
+++ b/docs/include/excel.md
@@ -1,5 +1,5 @@
-Install the [Spreadsheet adapter](https://github.com/portphp/spreadsheet):
+Install the [Excel adapter](https://github.com/portphp/excel):
 
 ```bash
-$ composer require portphp/spreadsheet
+$ composer require portphp/excel
 ```

--- a/docs/include/excel.md
+++ b/docs/include/excel.md
@@ -1,5 +1,5 @@
-Install the [Excel adapter](https://github.com/portphp/excel):
+Install the [Spreadsheet adapter](https://github.com/portphp/spreadsheet):
 
 ```bash
-$ composer require portphp/excel
+$ composer require portphp/spreadsheet
 ```

--- a/docs/include/spreadsheet.md
+++ b/docs/include/spreadsheet.md
@@ -1,0 +1,5 @@
+Install the [Spreadsheet adapter](https://github.com/portphp/spreadsheet):
+
+```bash
+$ composer require portphp/spreadsheet
+```

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -172,9 +172,37 @@ $reader = new DoctrineReader($objectManager, 'YourNamespace:Employee');
 
 ## Excel
 
-An adapter for the [PHPSpreadsheet library](https://phpspreadsheet.readthedocs.io/). 
+An adapter for the [PHPExcel library](http://phpexcel.codeplex.com/). 
 
 {!include/excel.md!}
+
+Then use the reader to open an Excel file:
+
+```php
+use Port\Excel\ExcelReader;
+
+$file = new \SplFileObject('path/to/ecxel_file.xls');
+$reader = new ExcelReader($file);
+```
+
+To set the row number that headers will be read from, pass a number as the second
+argument.
+
+```php
+$reader = new ExcelReader($file, 2);
+```
+
+To read the specific sheet:
+
+```php
+$reader = new ExcelReader($file, null, 3);
+```
+
+## Spreadsheet
+
+An adapter for the [PHPSpreadsheet library](https://phpspreadsheet.readthedocs.io/). 
+
+{!include/spreadsheet.md!}
 
 Then use the reader to open an Excel file:
 

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -172,30 +172,30 @@ $reader = new DoctrineReader($objectManager, 'YourNamespace:Employee');
 
 ## Excel
 
-An adapter for the [PHPExcel library](http://phpexcel.codeplex.com/). 
+An adapter for the [PHPSpreadsheet library](https://phpspreadsheet.readthedocs.io/). 
 
 {!include/excel.md!}
 
 Then use the reader to open an Excel file:
 
 ```php
-use Port\Excel\ExcelReader;
+use Port\Spreadsheet\SpreadsheetReader;
 
 $file = new \SplFileObject('path/to/ecxel_file.xls');
-$reader = new ExcelReader($file);
+$reader = new SpreadsheetReader($file);
 ```
 
 To set the row number that headers will be read from, pass a number as the second
 argument.
 
 ```php
-$reader = new ExcelReader($file, 2);
+$reader = new SpreadsheetReader($file, 2);
 ```
 
 To read the specific sheet:
 
 ```php
-$reader = new ExcelReader($file, null, 3);
+$reader = new SpreadsheetReader($file, null, 3);
 ```
 
 ## OneToManyReader

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -29,7 +29,10 @@ Readers
 * For CSV reading, you now need the CSV package: 
   `$ composer require portphp/csv`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
-* For Excel reading, you now need the Spreadsheet package: 
+* For Excel reading, you now need the Excel package: 
+  `$ composer require portphp/excel`. See the [docs](https://portphp.readthedocs.io) 
+  for more information.
+* For Spreadsheet reading, you now need the Spreadsheet package: 
   `$ composer require portphp/spreadsheet`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
   
@@ -39,7 +42,10 @@ Writers
 * For CSV writing, you now need the CSV package: 
   `$ composer require portphp/csv`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
-* For Excel writing, you now need the Spreadsheet package: 
+* For Excel writing, you now need the Excel package: 
+  `$ composer require portphp/excel`. See the [docs](https://portphp.readthedocs.io) 
+  for more information.
+* For Spreadsheet writing, you now need the Spreadsheet package: 
   `$ composer require portphp/spreadsheet`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -29,8 +29,8 @@ Readers
 * For CSV reading, you now need the CSV package: 
   `$ composer require portphp/csv`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
-* For Excel reading, you now need the Excel package: 
-  `$ composer require portphp/excel`. See the [docs](https://portphp.readthedocs.io) 
+* For Excel reading, you now need the Spreadsheet package: 
+  `$ composer require portphp/spreadsheet`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
   
 Writers
@@ -39,8 +39,8 @@ Writers
 * For CSV writing, you now need the CSV package: 
   `$ composer require portphp/csv`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
-* For Excel writing, you now need the Excel package: 
-  `$ composer require portphp/excel`. See the [docs](https://portphp.readthedocs.io) 
+* For Excel writing, you now need the Spreadsheet package: 
+  `$ composer require portphp/spreadsheet`. See the [docs](https://portphp.readthedocs.io) 
   for more information.
 
 Converters

--- a/docs/writers.md
+++ b/docs/writers.md
@@ -77,11 +77,51 @@ the import file named 'Category' with an id, the writer will use metadata to get
 reference so that it can be associated properly. The DoctrineWriter will skip any association fields that are already
 objects in cases where a converter was used to retrieve the association.
 
-## SpreadsheetWriter
+## ExcelWriter
 
 Writes data to an Excel file. 
 
 {!include/excel.md!}
+
+Then construct an ExcelWriter:
+
+```php
+use Port\Excel\ExcelWriter;
+
+$file = new \SplFileObject('data.xlsx', 'w');
+$writer = new ExcelWriter($file);
+
+$writer->prepare();
+$writer->writeItem(['first', 'last']);
+$writer->writeItem(['first' => 'James', 'last' => 'Bond']);
+$writer->finish();
+```
+
+You can specify the name of the sheet to write to:
+
+```php
+$writer = new ExcelWriter($file, 'My sheet');
+```
+
+You can open an already existing file and add a sheet to it:
+
+```php
+$file = new \SplFileObject('data.xlsx', 'a');   // Open file with append mode
+$writer = new ExcelWriter($file, 'New sheet');
+```
+
+If you wish to overwrite an existing sheet instead, specify the name of the
+existing sheet:
+
+```php
+$writer = new ExcelWriter($file, 'Old sheet');
+```
+
+## SpreadsheetWriter
+
+Writes data to an Excel file. 
+
+{!include/spreadsheet.md!}
 
 Then construct an SpreadsheetWriter:
 

--- a/docs/writers.md
+++ b/docs/writers.md
@@ -77,19 +77,19 @@ the import file named 'Category' with an id, the writer will use metadata to get
 reference so that it can be associated properly. The DoctrineWriter will skip any association fields that are already
 objects in cases where a converter was used to retrieve the association.
 
-## ExcelWriter
+## SpreadsheetWriter
 
 Writes data to an Excel file. 
 
 {!include/excel.md!}
 
-Then construct an ExcelWriter:
+Then construct an SpreadsheetWriter:
 
 ```php
-use Port\Excel\ExcelWriter;
+use Port\Spreadsheet\SpreadsheetWriter;
 
 $file = new \SplFileObject('data.xlsx', 'w');
-$writer = new ExcelWriter($file);
+$writer = new SpreadsheetWriter($file);
 
 $writer->prepare();
 $writer->writeItem(['first', 'last']);
@@ -100,21 +100,21 @@ $writer->finish();
 You can specify the name of the sheet to write to:
 
 ```php
-$writer = new ExcelWriter($file, 'My sheet');
+$writer = new SpreadsheetWriter($file, 'My sheet');
 ```
 
 You can open an already existing file and add a sheet to it:
 
 ```php
 $file = new \SplFileObject('data.xlsx', 'a');   // Open file with append mode
-$writer = new ExcelWriter($file, 'New sheet');
+$writer = new SpreadsheetWriter($file, 'New sheet');
 ```
 
 If you wish to overwrite an existing sheet instead, specify the name of the
 existing sheet:
 
 ```php
-$writer = new ExcelWriter($file, 'Old sheet');
+$writer = new SpreadsheetWriter($file, 'Old sheet');
 ```
 
 ## PdoWriter


### PR DESCRIPTION
The new library is mostly a dropin replacement for the old one. I simply replaced all of the instances of excel with spreadsheet.

- portphp/excel becomes portphp/spreadsheet
- Excel* becomes Spreadsheet*

This fixes #90