### PR TITLE
doc/readers/doctrine: add ::class example

### DIFF
--- a/docs/readers.md
+++ b/docs/readers.md
@@ -168,6 +168,8 @@ Then use the reader:
 use Port\Doctrine\DoctrineReader;
 
 $reader = new DoctrineReader($objectManager, 'YourNamespace:Employee');
+// or
+$reader = new DoctrineReader($objectManager, YourNamespace\Model\ModelName::class);
 ```
 
 ## Excel


### PR DESCRIPTION
for me the given `'YourNamespace:Employee'` did not work, but class name did.