### PR TITLE
Bumped php, psr/log and symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "docs": "https://portphp.readthedocs.org"
     },
     "require": {
-        "php": ">=7.4",
-        "psr/log": "~1.0",
-        "symfony/property-access": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "php": ">=7.4|^8.0|^8.1",
+        "psr/log": "^1.0|^2.0|^3.0",
+        "symfony/property-access": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^6.1",
+        "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^6.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The latest version cannot be installed within a Symfony 6.1 project (with PHP 8.1). The following error message occurs:

```
composer require portphp/portphp
Using version ^1.7 for portphp/portphp
./composer.json has been updated
Running composer update portphp/portphp
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires portphp/portphp ^1.7 -> satisfiable by portphp/portphp[1.7.0].
    - portphp/portphp 1.7.0 requires psr/log ~1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
You can also try re-running composer require with an explicit version constraint, e.g. "composer require portphp/portphp:*" to figure out if any version is installable, or "composer require portphp/portphp:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Bumping necessary packages does the job here! :)

