### PR TITLE
Remove unused psr/log and stop allowing EOL dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,8 @@
     },
     "require": {
         "php": ">=7.4",
-        "psr/log": "~1.0",
-        "symfony/property-access": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
+        "symfony/validator": "^4.4 || ^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`psr/log` [seems to be unused](https://github.com/portphp/portphp/pull/131#issuecomment-1253219139). I also dropped support for versions of Symfony that are EOL.  