### PR TITLE
Allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require": {
         "php": ">=7.4",
-        "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
-        "symfony/validator": "^4.4 || ^5.4 || ^6.0"
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0 || ^7.0",
+        "symfony/validator": "^4.4 || ^5.4 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Symfony 7 will be released soon and it would be great for Port to work with it.

* Port doesn't use any deprecated functionality in Symfony 6 and there are no concerning-looking breaks in the [7.0 changelog](https://github.com/symfony/symfony/blob/7.0/CHANGELOG-7.0.md).
* Tests pass when run against Symfony 7.0.0-RC1.