### PR TITLE
Update README CI badges and drop Scrutinizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,6 @@ tests/           export-ignore
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore
-.scrutinizer.yml export-ignore
-.travis.yml      export-ignore
 CONTRIBUTING.md  export-ignore
 phpspec.yml.dist export-ignore
 phpunit.xml.dist export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,0 @@
-checks:
-  php:
-    code_rating: true
-    duplication: true
-
-tools:
-  external_code_coverage: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # portphp/portphp
 
 [![Latest Version](https://img.shields.io/github/release/portphp/portphp.svg?style=flat-square)](https://github.com/portphp/portphp/releases)
-[![Build Status](https://travis-ci.org/portphp/portphp.svg)](https://travis-ci.org/portphp/portphp)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/portphp/portphp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/portphp/portphp/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/portphp/portphp/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/portphp/portphp/?branch=master)
+[![CI](https://github.com/portphp/portphp/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/portphp/actions)
+[![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue.svg?style=flat-square)](https://github.com/portphp/portphp/actions)
+
+**Supported PHP (CI):** 8.2, 8.3, 8.4, and 8.5.
+
 
 Port is a data import/export workflow for PHP.
 
@@ -22,7 +24,7 @@ of the Composer documentation.
 
 ## Documentation
 
-Documentation is available at https://portphp.readthedocs.org.
+Documentation is available at https://portphp.readthedocs.io.
 
 ## Issues and feature requests
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # portphp/portphp
 
 [![Latest Version](https://img.shields.io/github/release/portphp/portphp.svg?style=flat-square)](https://github.com/portphp/portphp/releases)
-[![CI](https://github.com/portphp/portphp/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/portphp/actions)
-[![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue.svg?style=flat-square)](https://github.com/portphp/portphp/actions)
+[![CI](https://github.com/portphp/portphp/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/portphp/actions/workflows/test.yml)
+[![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue.svg?style=flat-square)](https://github.com/portphp/portphp/actions/workflows/test.yml)
 
 **Tested in CI:** 8.2, 8.3, 8.4, and 8.5.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/portphp/portphp/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/portphp/actions)
 [![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue.svg?style=flat-square)](https://github.com/portphp/portphp/actions)
 
-**Supported PHP (CI):** 8.2, 8.3, 8.4, and 8.5.
+**Tested in CI:** 8.2, 8.3, 8.4, and 8.5.
 
 
 Port is a data import/export workflow for PHP.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,14 @@
 {
     "name": "portphp/portphp",
     "description": "Data import/export workflow",
-    "keywords": [ "data", "import", "export", "csv", "excel", "doctrine" ],
+    "keywords": [
+        "data",
+        "import",
+        "export",
+        "csv",
+        "excel",
+        "doctrine"
+    ],
     "license": "MIT",
     "homepage": "https://github.com/portphp",
     "authors": [
@@ -21,7 +28,7 @@
     "support": {
         "issues": "https://github.com/portphp/portphp/issues",
         "source": "https://github.com/portphp/portphp",
-        "docs": "https://portphp.readthedocs.org"
+        "docs": "https://portphp.readthedocs.io"
     },
     "require": {
         "php": ">=7.4",


### PR DESCRIPTION
## Summary
Phase 0 README hygiene for the packages we modernized CI on.

- Replace dead Travis + Scrutinizer badges with GitHub Actions CI badge
- Document PHP versions exercised in CI (8.2–8.5)
- Point docs links at `https://portphp.readthedocs.io`
- Remove `.scrutinizer.yml` (we no longer upload coverage; Scrutinizer checks stay stuck)

## Test plan
- [x] CI still green on the PR
- [ ] Copilot review