### PR TITLE
Release 2.0.0: PHP ^8.2 and Symfony 5.4–8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    versioning-strategy: widen

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Latest Version](https://img.shields.io/github/release/portphp/portphp.svg?style=flat-square)](https://github.com/portphp/portphp/releases)
 [![CI](https://github.com/portphp/portphp/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/portphp/actions/workflows/test.yml)
-[![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue.svg?style=flat-square)](https://github.com/portphp/portphp/actions/workflows/test.yml)
+[![PHP Version](https://img.shields.io/packagist/php-v/portphp/portphp.svg?style=flat-square)](https://packagist.org/packages/portphp/portphp)
 
-**Tested in CI:** 8.2, 8.3, 8.4, and 8.5.
+**Requirements:** PHP ^8.2 (tested on 8.2–8.5).
 
 
 Port is a data import/export workflow for PHP.

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,17 @@
+# Upgrade from 1.x to 2.0
+
+## PHP
+
+- Minimum PHP version is now **8.2** (`^8.2`). PHP 7.4–8.1 are no longer supported.
+
+## Symfony components
+
+- `symfony/property-access` and `symfony/validator` now require:
+  `^5.4 || ^6.0 || ^7.0 || ^8.0`
+- Symfony 4.x is no longer supported.
+- Symfony 6.x is supported again (it was briefly missing on `master` before this release).
+
+## Other
+
+- CI runs on PHP 8.2–8.5 via GitHub Actions.
+- Scrutinizer configuration was removed; use GitHub Actions status instead.

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "docs": "https://portphp.readthedocs.io"
     },
     "require": {
-        "php": ">=7.4",
-        "symfony/property-access": "^5.4 || ^7.4 || ^8.0",
-        "symfony/validator": "^5.4 || ^7.4 || ^8.0"
+        "php": "^8.2",
+        "symfony/property-access": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/validator": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,8 +48,8 @@
     "require-dev": {
         "ext-iconv": "*",
         "ext-mbstring": "*",
-        "phpunit/phpunit": "^9.5",
-        "phpspec/phpspec": "^8.2",
+        "phpunit/phpunit": "^9.6",
+        "phpspec/phpspec": "^8.0",
         "doctrine/instantiator": "^2.0",
         "doctrine/common": "^3.0"
     },


### PR DESCRIPTION
## Summary
**Major release** dropping EOL PHP. Aligns runtime constraints with CI.

### Breaking
- `php`: `^8.2` (was `>=7.4`)
- `symfony/property-access` / `symfony/validator`: `^5.4 || ^6.0 || ^7.0 || ^8.0`
  - Restores Symfony **6.x** (was accidentally dropped on master)
  - Drops Symfony 4.x
  - Keeps all Symfony lines that run on PHP 8.2+

### Other
- Dependabot (GitHub Actions weekly, Composer monthly)
- `UPGRADE-2.0.md`
- README requirements updated

## Test plan
- [x] CI PHP 8.2–8.5
- [ ] Copilot review
- [ ] Tag `2.0.0` after merge